### PR TITLE
added unzip

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -58,7 +58,7 @@ RUN docker-php-ext-install soap
 ENV COMPOSER_HOME=/composer
 COPY --from=composer:1.6.5 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get -y install git vim mysql-client rsync sshpass bzip2 msmtp
+RUN apt-get update && apt-get -y install git vim mysql-client rsync sshpass bzip2 msmtp unzip
 
 ADD php.ini /usr/local/etc/php/php.ini
 

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -58,7 +58,7 @@ RUN docker-php-ext-install soap
 ENV COMPOSER_HOME=/composer
 COPY --from=composer:1.6.5 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get -y install git vim mysql-client rsync sshpass bzip2 msmtp
+RUN apt-get update && apt-get -y install git vim mysql-client rsync sshpass bzip2 msmtp unzip
 
 ADD php.ini /usr/local/etc/php/php.ini
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -58,7 +58,7 @@ RUN docker-php-ext-install soap
 ENV COMPOSER_HOME=/composer
 COPY --from=composer:1.6.5 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get install -y git vim mysql-client rsync sshpass bzip2 msmtp
+RUN apt-get update && apt-get install -y git vim mysql-client rsync sshpass bzip2 msmtp unzip
 
 ADD php.ini /usr/local/etc/php/php.ini
 

--- a/7.0/Dockerfile
+++ b/7.0/Dockerfile
@@ -58,7 +58,7 @@ RUN docker-php-ext-install soap
 ENV COMPOSER_HOME=/composer
 COPY --from=composer:1.6.5 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get install -y git vim mysql-client rsync sshpass bzip2 msmtp
+RUN apt-get update && apt-get install -y git vim mysql-client rsync sshpass bzip2 msmtp unzip
 
 ADD php.ini /usr/local/etc/php/php.ini
 

--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -58,7 +58,7 @@ RUN docker-php-ext-install soap
 ENV COMPOSER_HOME=/composer
 COPY --from=composer:1.6.5 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get install -y git vim mysql-client rsync sshpass bzip2 msmtp
+RUN apt-get update && apt-get install -y git vim mysql-client rsync sshpass bzip2 msmtp unzip
 
 ADD php.ini /usr/local/etc/php/php.ini
 

--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -56,7 +56,7 @@ RUN docker-php-ext-install soap
 ENV COMPOSER_HOME=/composer
 COPY --from=composer:1.6.5 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get install -y git vim mysql-client rsync sshpass bzip2 msmtp
+RUN apt-get update && apt-get install -y git vim mysql-client rsync sshpass bzip2 msmtp unzip
 
 ADD php.ini /usr/local/etc/php/php.ini
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This is a docker php fpm image, based on the official php fpm image. It has the 
 - sshpass (1.05)
 - bzip2
 - msmtp
+- unzip
 - cron/crontab with `start-cron` executable
 - `max_execution_time=0` even in php-fpm (use `PHP_MAX_EXECUTION_TIME` environment variable to override it)
 - possibility to override special php ini settings with environment variables: (see included php.ini for a full list, see [this blog post for reasons](https://dracoblue.net/dev/use-environment-variables-for-php-ini-settings-in-docker/)):


### PR DESCRIPTION
Composer shows the following warning:

```
<warn>As there is no 'unzip' command installed zip files are being unpacked using the PHP zip extension.</warn>
<warn>This may cause invalid reports of corrupted archives. Installing 'unzip' may remediate them.</warn>
```