### PR TITLE
remove ssh2 extension from php 7.3

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -1,11 +1,5 @@
 FROM php:7.3-fpm
 
-## ssh2
-#RUN apt-get update && apt-get install -y libssh2-1-dev libssh2-1
-#RUN pecl install ssh2-1.1.2
-#RUN echo extension=ssh2.so >> /usr/local/etc/php/conf.d/ssh2.ini
-## ssh2
-
 RUN apt-get update && apt-get install -y libz-dev libmemcached-dev
 RUN pecl install memcached-3.1.2
 RUN echo extension=memcached.so >> /usr/local/etc/php/conf.d/memcached.ini

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is a docker php fpm image, based on the official php fpm image. It has the 
   - calendar
   - ldap
   - redis
-  - ssh2 (0.13 for php 5 and 1.1.3 for php 7 https://pecl.php.net/package/ssh2, currently disabled in 7.3)
+  - ssh2 (0.13 for php 5 and 1.1.3 for php 7 https://pecl.php.net/package/ssh2, not available in 7.3)
   - amqp (1.9.1 for php <= 5.6, 1.9.3 for php <= 7.2, 1.9.4 for php 7.3)
   - sockets
 - composer cli (1.8.4)


### PR DESCRIPTION
Refs #66 