### PR TITLE
Use explicit redis version

### DIFF
--- a/5.4/Dockerfile
+++ b/5.4/Dockerfile
@@ -47,7 +47,7 @@ RUN docker-php-ext-install calendar
 RUN docker-php-ext-install mcrypt
 RUN docker-php-ext-install sockets
 
-RUN pecl install redis \
+RUN pecl install redis-4.3.0 \
     && docker-php-ext-enable redis
 
 # ldap

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This is a docker php fpm image, based on the official php fpm image. It has the 
   - xsl
   - calendar
   - ldap
-  - redis
+  - redis (4.3.0)
   - ssh2 (0.13)
   - amqp (1.9.1)
   - sockets


### PR DESCRIPTION
If this works, it needs to be done for `release/5.5` and `release/5.6`, too