### PR TITLE
Remove unsupported PHP version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ env:
   - PHP_VERSION=7.0.22
   - PHP_VERSION=7.0.20
   - PHP_VERSION=7.0.17
-  - PHP_VERSION=7.0.16
 
 before_deploy:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"


### PR DESCRIPTION
Some problems with LDAP, but only in this version. Not worth do dive deeper IMO

Decision based on this build https://travis-ci.org/exozet/docker-php-fpm/builds/566342047