### PR TITLE
debian buster uses default-mysql-client instead of mysql-client.

### DIFF
--- a/7.3/Dockerfile
+++ b/7.3/Dockerfile
@@ -60,7 +60,7 @@ RUN docker-php-ext-install soap
 ENV COMPOSER_HOME=/composer
 COPY --from=composer:1.8.6 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get install -y git vim mysql-client rsync sshpass bzip2 msmtp unzip
+RUN apt-get update && apt-get install -y git vim default-mysql-client rsync sshpass bzip2 msmtp unzip
 
 ADD php.ini /usr/local/etc/php/php.ini
 


### PR DESCRIPTION
Currently it's not possible to make a clean build of exozet/docker-php-fpm:7.3. The base image php:7.3 switched from stretch to buster and buster has no mysql-client anymore. Therefore building fails.
It's either possible to switch from php:7.3-fpm to php:7.3-fpm-stretch or use default-mysql-client instead of mysql-client - that's what this is about (default-mysql-client is available in stretch too).