### PR TITLE
debian buster uses default-mysql-client instead of mysql-client.

### DIFF
--- a/7.1/Dockerfile
+++ b/7.1/Dockerfile
@@ -68,7 +68,7 @@ RUN docker-php-ext-install soap
 ENV COMPOSER_HOME=/composer
 COPY --from=composer:1.8.6 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get install -y git vim mysql-client rsync sshpass bzip2 msmtp unzip
+RUN apt-get update && apt-get install -y git vim default-mysql-client rsync sshpass bzip2 msmtp unzip
 
 ADD php.ini /usr/local/etc/php/php.ini
 


### PR DESCRIPTION
Cherry picked from https://github.com/exozet/docker-php-fpm/pulls?q=is%3Apr+is%3Aclosed