### PR TITLE
Fixed missing gd jpeg support

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -16,10 +16,11 @@ RUN apt-get update && apt-get install -y \
   libssh-dev \
   libwebp-dev  # php >=7.0 (use libvpx for php <7.0)
 RUN docker-php-ext-configure gd \
-    --with-freetype-dir=/usr/include/ \
-    --with-jpeg-dir=/usr/include/ \
-    --with-xpm-dir=/usr/include \
-    --with-webp-dir=/usr/include/ # php >=7.0 (use libvpx for php <7.0)
+    --enable-gd \
+    --with-freetype \
+    --with-jpeg \
+    --with-xpm \
+    --with-webp
 RUN docker-php-ext-install gd
 
 RUN pecl install amqp-1.9.4

--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -108,6 +108,5 @@ RUN apt-get install -y libpq-dev \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo_pgsql pgsql
 
-# not working yet. build failed with the newest version
-#RUN pecl install pcov-1.0.3
-#RUN docker-php-ext-enable pcov
+RUN pecl install pcov-1.0.6
+RUN docker-php-ext-enable pcov

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is a docker php fpm image, based on the official php fpm image. It has the 
   - pdo_mysql (5.0.11-dev)
   - pdo_pgsql
   - pgsql
+  - pcov (1.0.6)
   - xdebug (2.8.1)
   - opcache
   - pcntl


### PR DESCRIPTION
They are new gd configuration parameters in version 7.4.0 (see https://github.com/docker-library/php/issues/920#issuecomment-562864296)

I don't now why the last commit has worked, because after niepi created the issue i build the 7.4 image again on my computer an get an error, that some options in `docker-php-ext-configure gd` not exists anymore.

I changed the options and it worked now.

Before: (image is from dockerhub)
```
docker run --rm -it exozet/php-fpm:7.4.0 bash -c "php -i | grep ^gd$ -A11"
gd

GD Support => enabled
GD Version => bundled (2.1.0 compatible)
GIF Read Support => enabled
GIF Create Support => enabled
PNG Support => enabled
libPNG Version => 1.6.36
WBMP Support => enabled
XBM Support => enabled
BMP Support => enabled
TGA Read Support => enabled
```
After: (local image build with this fix)
```
docker run --rm -it exozet/php-fpm:7.4.0 bash -c "php -i | grep ^gd$ -A20"
gd

GD Support => enabled
GD Version => bundled (2.1.0 compatible)
FreeType Support => enabled
FreeType Linkage => with freetype
FreeType Version => 2.9.1
GIF Read Support => enabled
GIF Create Support => enabled
JPEG Support => enabled
libJPEG Version => 6b
PNG Support => enabled
libPNG Version => 1.6.36
WBMP Support => enabled
XPM Support => enabled
libXpm Version => 30411
XBM Support => enabled
WebP Support => enabled
BMP Support => enabled
TGA Read Support => enabled
```

JPEG support is now enabled.