### PR TITLE
Added option --no-install-recommends to apt-get install

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -1,11 +1,13 @@
 FROM php:7.4-fpm
 
-RUN apt-get update && apt-get install -y libz-dev libmemcached-dev
+RUN apt-get update && apt-get install --no-install-recommends -y libz-dev libmemcached-dev \
+    && rm -rf /var/lib/apt/lists/*
 RUN pecl install memcached-3.1.2
 RUN echo extension=memcached.so >> /usr/local/etc/php/conf.d/memcached.ini
 
 # gd extension
-RUN apt-get update && apt-get install -y \
+# php >=7.0 (use libvpx for php <7.0)
+RUN apt-get update && apt-get install --no-install-recommends -y \
   libpng-dev \
   libfreetype6-dev \
   libjpeg-dev \
@@ -14,7 +16,8 @@ RUN apt-get update && apt-get install -y \
   libxslt-dev \
   librabbitmq-dev \
   libssh-dev \
-  libwebp-dev  # php >=7.0 (use libvpx for php <7.0)
+  libwebp-dev \
+  && rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-configure gd \
     --enable-gd \
     --with-freetype \
@@ -26,11 +29,13 @@ RUN docker-php-ext-install gd
 RUN pecl install amqp-1.9.4
 RUN docker-php-ext-enable amqp
 
-RUN apt-get update && apt-get install -y libz-dev libzip-dev
+RUN apt-get update && apt-get install --no-install-recommends -y libz-dev libzip-dev \
+    && rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install xsl
 
-RUN apt-get update && apt-get install -y libicu-dev
+RUN apt-get update && apt-get install --no-install-recommends -y libicu-dev \
+    && rm -rf /var/lib/apt/lists/*
 RUN docker-php-ext-install intl
 
 RUN docker-php-ext-install mysqli
@@ -44,10 +49,10 @@ RUN pecl install redis \
     && docker-php-ext-enable redis
 
 # ldap
-RUN apt-get update && apt-get install libldap2-dev -y && \
-    rm -rf /var/lib/apt/lists/* && \
-    docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ && \
-    docker-php-ext-install ldap
+RUN apt-get update && apt-get install --no-install-recommends libldap2-dev -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+    && docker-php-ext-install ldap
 # ldap
 
 RUN docker-php-ext-configure pcntl --enable-pcntl \
@@ -61,12 +66,15 @@ RUN docker-php-ext-install soap
 ENV COMPOSER_HOME=/composer
 COPY --from=composer:1.8.6 /usr/bin/composer /usr/local/bin/composer
 
-RUN apt-get update && apt-get install -y git vim default-mysql-client rsync sshpass bzip2 msmtp unzip
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    git vim default-mysql-client rsync sshpass bzip2 msmtp unzip \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD php.ini /usr/local/etc/php/php.ini
 
 # Cron
-RUN apt-get update && apt-get install -y cron \
+RUN apt-get update && apt-get install --no-install-recommends -y cron \
+    && rm -rf /var/lib/apt/lists/* \
     && mkfifo --mode 0666 /var/log/cron.log \
     && sed --regexp-extended --in-place \
     's/^session\s+required\s+pam_loginuid.so$/session optional pam_loginuid.so/' \
@@ -99,12 +107,14 @@ ENV PHP_DATE_TIMEZONE="" \
 WORKDIR /usr/src/app
 
 # imagick
-RUN apt-get update && apt-get install -y libmagickwand-dev \
+RUN apt-get update && apt-get install --no-install-recommends -y libmagickwand-dev \
+    && rm -rf /var/lib/apt/lists/* \
     && pecl install imagick \
     && docker-php-ext-enable imagick
 
-# Install Postgre PDO
-RUN apt-get install -y libpq-dev \
+# Install Postgres PDO
+RUN apt-get update && apt-get install --no-install-recommends -y libpq-dev \
+    && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-install pdo_pgsql pgsql
 

--- a/build_version.sh
+++ b/build_version.sh
@@ -39,7 +39,7 @@ rm -f version-Dockerfile
 echo "FROM php:${PHP_VERSION}-fpm" >> sudo-Dockerfile
 cat Dockerfile | grep -v '^FROM' >> sudo-Dockerfile
 echo '' >> sudo-Dockerfile
-echo 'RUN apt-get install sudo' >> sudo-Dockerfile
+echo 'RUN apt-get update && apt-get install --no-install-recommends sudo && rm -rf /var/lib/apt/lists/*' >> sudo-Dockerfile
 echo 'RUN chsh www-data -s /bin/bash' >> sudo-Dockerfile
 echo 'RUN echo "www-data ALL = NOPASSWD: ALL" > /etc/sudoers.d/www-data' >> sudo-Dockerfile
 


### PR DESCRIPTION
Also delete files in /var/lib/apt/lists/.

These both optimization saving ~ 125 MB without changing the Dockerfile to much.

Before:

```
docker image ls | grep 7.4.0
exozet/php-fpm                                                     7.4.0-root          96e87341ddfc        13 hours ago        1.04GB
exozet/php-fpm                                                     7.4.0-sudo          8e988d15e19c        13 hours ago        1.05GB
exozet/php-fpm                                                     7.4.0               f5984b18a016        13 hours ago        1.04GB
```

After:

```
docker image ls | grep 7.4
exozet/php-fpm                                                     7.4.0-root          bfcaab78a9d4        About a minute ago   877MB
exozet/php-fpm                                                     7.4.0-sudo          c44e02585d73        About a minute ago   880MB
exozet/php-fpm                                                     7.4.0               d6a5ad898d52        About a minute ago   877MB
```