### PR TITLE
Upgrade PHP 7.2 Xdebug to 2.9.0

### DIFF
--- a/7.2/Dockerfile
+++ b/7.2/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update && apt-get install libldap2-dev -y && \
 RUN docker-php-ext-configure pcntl --enable-pcntl \
     && docker-php-ext-install pcntl
 
-RUN pecl install xdebug-2.6.1
+RUN pecl install xdebug-2.9.0
 RUN echo "zend_extension=`php -i | grep ^extension_dir | cut -f 3 -d ' '`/xdebug.so" >> /usr/local/etc/php/conf.d/xdebug.ini
 
 RUN docker-php-ext-install soap

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a docker php fpm image, based on the official php fpm image. It has the 
   - pdo_mysql (5.0.11-dev)
   - pdo_pgsql
   - pgsql
-  - xdebug (2.6.1)
+  - xdebug (2.9.0)
   - pcov (1.0.0)
   - opcache
   - pcntl


### PR DESCRIPTION
Its much faster:
https://twitter.com/Xdebug/status/1204032464924094465

Not sure the build will be green, or if we already use the last supported version for this PHP version.
If the build fails, just close this PR.