### PR TITLE
Fixed variable name for php version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,10 @@ jobs:
                     username: ${{ secrets.QUAY_USERNAME }}
                     password: ${{ secrets.QUAY_PASSWORD }}
 
-            -   if: contains(github.ref, 'refs/heads/release/') && matrix.php_version == env.VERSION_FOR_ALIAS
+            -   if: contains(github.ref, 'refs/heads/release/') && matrix.php-version == env.VERSION_FOR_ALIAS
                 name: "Push PHP ${{ matrix.php-version }} and for version alias ${{ env.ALIAS_VERSION }}"
                 run: ./push_version.sh ${{ matrix.php-version }} ${{ env.ALIAS_VERSION }}
 
-            -   if: contains(github.ref, 'refs/heads/release/') && matrix.php_version != env.VERSION_FOR_ALIAS
+            -   if: contains(github.ref, 'refs/heads/release/') && matrix.php-version != env.VERSION_FOR_ALIAS
                 name: "Push PHP ${{ matrix.php-version }}"
                 run: ./push_version.sh ${{ matrix.php-version }}


### PR DESCRIPTION
Now the comparison of the PHP versions makes sense again and the major.minor image can be pushed / updated. Fixes #189