### PR TITLE
Added php version targets 7.4.18, 7.4.19 and 7.4.20.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
     ALIAS_VERSION: '7.4'
-    VERSION_FOR_ALIAS: '7.4.16'
+    VERSION_FOR_ALIAS: '7.4.20'
 
 jobs:
     ci:
@@ -21,6 +21,9 @@ jobs:
         strategy:
             matrix:
                 php-version:
+                    - '7.4.20'
+                    - '7.4.19'
+                    - '7.4.18'
                     - '7.4.16'
                     - '7.4.15'
                     - '7.4.14'


### PR DESCRIPTION
I added PHP version targets for 7.4.18, 7.4.19 and 7.4.20. There seems to be no version 7.4.17.