### PR TITLE
Include libgomp

### DIFF
--- a/8.0/Dockerfile-alpine
+++ b/8.0/Dockerfile-alpine
@@ -94,7 +94,7 @@ RUN cp `php -i | grep ^extension_dir | cut -f 3 -d ' '`/*.so /tmp/
 
 # install master version of imagick extension, @TODO upgrade to release version when php8 support is ready
 FROM build-base AS build-imagick
-RUN apk add --no-cache imagemagick-dev libgomp
+RUN apk add --no-cache imagemagick-dev
 RUN docker-php-source extract \
     && mkdir /usr/src/php/ext/imagick \
     && curl -L https://github.com/imagick/imagick/archive/master.tar.gz | tar -xzC /usr/src/php/ext/imagick --strip-components=1 \
@@ -223,7 +223,7 @@ RUN mv /tmp/memcached.so `php -i | grep ^extension_dir | cut -f 3 -d ' '`/ \
 
 COPY --from=build-imagick /tmp/imagick.so /tmp/imagick.so
 RUN mv /tmp/imagick.so `php -i | grep ^extension_dir | cut -f 3 -d ' '`/ \
-    && apk add --no-cache imagemagick \
+    && apk add --no-cache imagemagick libgomp \
     && docker-php-ext-enable imagick
 
 COPY --from=build-pgsql /tmp/pgsql.so /tmp/pgsql.so


### PR DESCRIPTION
PHP 8.0.6 alpine `imagick` seems to have an unmet dependency to `libgomp`. 

`usr/src/app # php -v
PHP Warning:  PHP Startup: Unable to load dynamic library 'imagick' (tried: /usr/local/lib/php/extensions/no-debug-non-zts-20200930/imagick (Error loading shared library /usr/local/lib/php/extensions/no-debug-non-zts-20200930/imagick: No such file or directory), /usr/local/lib/php/extensions/no-debug-non-zts-20200930/imagick.so (Error loading shared library libgomp.so.1: No such file or directory (needed by /usr/local/lib/php/extensions/no-debug-non-zts-20200930/imagick.so))) in Unknown on line 0

Warning: PHP Startup: Unable to load dynamic library 'imagick' (tried: /usr/local/lib/php/extensions/no-debug-non-zts-20200930/imagick (Error loading shared library /usr/local/lib/php/extensions/no-debug-non-zts-20200930/imagick: No such file or directory), /usr/local/lib/php/extensions/no-debug-non-zts-20200930/imagick.so (Error loading shared library libgomp.so.1: No such file or directory (needed by /usr/local/lib/php/extensions/no-debug-non-zts-20200930/imagick.so))) in Unknown on line 0
PHP 8.0.6 (cli) (built: May  7 2021 20:55:41) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.6, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.6, Copyright (c), by Zend Technologies
`