### PR TITLE
Fix CVEs in Php 8.1 Alpine and Standard Images and add Trivy Scanner Report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,16 @@ jobs:
             -   name: "Check Standard -v"
                 run: docker run --rm -t exozet/php-fpm:${{ matrix.php-version }} php -v
 
+            -   name: Run Trivy vulnerability scanner
+                uses: aquasecurity/trivy-action@master
+                with:
+                  image-ref: 'exozet/php-fpm:${{ matrix.php-version }}'
+                  format: 'table'
+                  exit-code: '0' # we don't break the build if vulnerabilities are included!
+                  ignore-unfixed: true
+                  vuln-type: 'os,library'
+                  severity: 'CRITICAL,HIGH'
+
             -   if: contains(github.ref, 'refs/heads/release/')
                 name: Login to DockerHub
                 uses: docker/login-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,18 @@ jobs:
                   vuln-type: 'os,library'
                   severity: 'CRITICAL,HIGH'
 
+            -   name: Run Trivy vulnerability scanner and upload to github security tab
+                uses: aquasecurity/trivy-action@master
+                with:
+                  image-ref: 'exozet/php-fpm:${{ matrix.php-version }}'
+                  format: 'sarif'
+                  output: 'trivy-results.sarif'
+
+            -   name: Upload Trivy scan results to GitHub Security tab
+                uses: github/codeql-action/upload-sarif@v1
+                with:
+                  sarif_file: 'trivy-results.sarif'
+          
             -   if: contains(github.ref, 'refs/heads/release/')
                 name: Login to DockerHub
                 uses: docker/login-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,24 +46,24 @@ jobs:
             -   name: "Check Standard -v"
                 run: docker run --rm -t exozet/php-fpm:${{ matrix.php-version }} php -v
 
-            -   name: Run Trivy vulnerability scanner
+            -   name: Run Alpine Trivy vulnerability scanner
                 uses: aquasecurity/trivy-action@master
                 with:
-                  image-ref: 'exozet/php-fpm:${{ matrix.php-version }}'
+                  image-ref: 'exozet/php-fpm:${{ matrix.php-version }}-alpine'
                   format: 'table'
                   exit-code: '0' # we don't break the build if vulnerabilities are included!
                   ignore-unfixed: true
                   vuln-type: 'os,library'
                   severity: 'CRITICAL,HIGH'
 
-            -   name: Run Trivy vulnerability scanner and upload to github security tab
+            -   name: Run Alpine Trivy vulnerability scanner and upload to github security tab
                 uses: aquasecurity/trivy-action@master
                 with:
-                  image-ref: 'exozet/php-fpm:${{ matrix.php-version }}'
+                  image-ref: 'exozet/php-fpm:${{ matrix.php-version }}-alpine'
                   format: 'sarif'
                   output: 'trivy-results.sarif'
 
-            -   name: Upload Trivy scan results to GitHub Security tab
+            -   name: Upload Alpine Trivy scan results to GitHub Security tab
                 uses: github/codeql-action/upload-sarif@v1
                 with:
                   sarif_file: 'trivy-results.sarif'

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.1-fpm
 
-RUN apt-get update && apt-get dist-upgrade && echo "Security Update enforced on 2022/04/01"
+RUN apt-get update && apt-get dist-upgrade -y && echo "Security Update enforced on 2022/04/01"
 
 RUN apt-get update && apt-get install --no-install-recommends -y libz-dev libmemcached-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:8.1-fpm
 
+RUN apt-get update && apt-get dist-ugprade && echo "Security Update enforced on 2022/04/01"
+
 RUN apt-get update && apt-get install --no-install-recommends -y libz-dev libmemcached-dev \
     && rm -rf /var/lib/apt/lists/*
 RUN pecl install memcached-3.1.5

--- a/8.1/Dockerfile
+++ b/8.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:8.1-fpm
 
-RUN apt-get update && apt-get dist-ugprade && echo "Security Update enforced on 2022/04/01"
+RUN apt-get update && apt-get dist-upgrade && echo "Security Update enforced on 2022/04/01"
 
 RUN apt-get update && apt-get install --no-install-recommends -y libz-dev libmemcached-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/8.1/Dockerfile-alpine
+++ b/8.1/Dockerfile-alpine
@@ -129,6 +129,8 @@ COPY --from=composer:2.2 /usr/bin/composer /usr/local/bin/composer2
 COPY composer /usr/local/bin
 RUN chmod +x /usr/local/bin/composer
 
+RUN apk upgrade libsasl libssl1.1 openssl zlib libxml2 libretls libcrypto1.1
+
 RUN apk add --no-cache \
     git \
     git-lfs \


### PR DESCRIPTION
Before Alpine:
```console
$ trivy image quay.io/exozet/php-fpm:8.1.1-xdebug-alpine
2022-03-31T22:15:51.997Z	INFO	Need to update DB
2022-03-31T22:15:51.999Z	INFO	Downloading DB...
30.98 MiB / 30.98 MiB [---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% 4.56 MiB p/s 7.0s
2022-03-31T22:16:19.990Z	INFO	Detected OS: alpine
2022-03-31T22:16:19.990Z	INFO	Detecting Alpine vulnerabilities...
2022-03-31T22:16:20.025Z	INFO	Number of language-specific files: 1
2022-03-31T22:16:20.026Z	INFO	Detecting gobinary vulnerabilities...

quay.io/exozet/php-fpm:8.1.1-xdebug-alpine (alpine 3.15.0)
==========================================================
Total: 7 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 7, CRITICAL: 0)

+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| libcrypto1.1 | CVE-2022-0778    | HIGH     | 1.1.1l-r7         | 1.1.1n-r0     | openssl: Infinite loop in             |
|              |                  |          |                   |               | BN_mod_sqrt() reachable               |
|              |                  |          |                   |               | when parsing certificates             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-0778  |
+--------------+                  +          +-------------------+---------------+                                       +
| libretls     |                  |          | 3.3.4-r2          | 3.3.4-r3      |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| libsasl      | CVE-2022-24407   |          | 2.1.27-r14        | 2.1.28-r0     | cyrus-sasl: failure to properly       |
|              |                  |          |                   |               | escape SQL input allows               |
|              |                  |          |                   |               | an attacker to execute...             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-24407 |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| libssl1.1    | CVE-2022-0778    |          | 1.1.1l-r7         | 1.1.1n-r0     | openssl: Infinite loop in             |
|              |                  |          |                   |               | BN_mod_sqrt() reachable               |
|              |                  |          |                   |               | when parsing certificates             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-0778  |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| libxml2      | CVE-2022-23308   |          | 2.9.12-r2         | 2.9.13-r0     | libxml2: Use-after-free               |
|              |                  |          |                   |               | of ID and IDREF attributes            |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-23308 |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| openssl      | CVE-2022-0778    |          | 1.1.1l-r7         | 1.1.1n-r0     | openssl: Infinite loop in             |
|              |                  |          |                   |               | BN_mod_sqrt() reachable               |
|              |                  |          |                   |               | when parsing certificates             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-0778  |
+--------------+------------------+          +-------------------+---------------+---------------------------------------+
| zlib         | CVE-2018-25032   |          | 1.2.11-r3         | 1.2.12-r0     | zlib: A flaw in zlib-1.2.11           |
|              |                  |          |                   |               | when compressing (not                 |
|              |                  |          |                   |               | decompressing!) certain inputs.       |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-25032 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+

usr/bin/git-lfs (gobinary)
==========================
Total: 1 (UNKNOWN: 1, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

+-------------------+------------------+----------+-------------------+---------------+---------------------------------------+
|      LIBRARY      | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+-------------------+------------------+----------+-------------------+---------------+---------------------------------------+
| golang.org/x/text | CVE-2021-38561   | UNKNOWN  | v0.3.5            | 0.3.7         | Due to improper index calculation,    |
|                   |                  |          |                   |               | an incorrectly formatted              |
|                   |                  |          |                   |               | language tag can cause...             |
|                   |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2021-38561 |
+-------------------+------------------+----------+-------------------+---------------+---------------------------------------+
```

Before Non-Alpine: quay.io/exozet/php-fpm:8.1.0-root:
```
 45 Critical-level vulnerabilities.
 339 High-level vulnerabilities.
 357 Medium-level vulnerabilities.
 31 Low-level vulnerabilities.
 120 Unknown-level vulnerabilities.
```

